### PR TITLE
strip possible whitespaces in domain list when reading from file

### DIFF
--- a/checkssl
+++ b/checkssl
@@ -274,6 +274,7 @@ debug "completed creating list of domains"
 # read domains from file 
 while IFS= read -r DOMAIN; do
   if [ ! -z "$DOMAIN" ]; then
+    DOMAIN="$(echo -e "${DOMAIN}" | tr -d '[[:space:]]')"
     PROBLEMS=""
     debug " --------------- domain ${DOMAIN}  ---------------------"
     CERTINFO=$(echo | openssl s_client -servername "${DOMAIN}" -connect "${DOMAIN}:443" 2>/dev/null | openssl x509 2>/dev/null)


### PR DESCRIPTION
When a hostname read from a file contains a trailing whitespace, the result checkssl gave was "no certificate found". This is due to the command line of openssl calls, that is then constructed.
To prevent problems, the domain name is stripped from all whitespace. 
