### PR TITLE
modify CN parse from certinfo

### DIFF
--- a/checkssl
+++ b/checkssl
@@ -358,7 +358,7 @@ while IFS= read -r LINE; do
     debug " --------------- domain ${DOMAIN}:${PORT} ${REMOTE_EXTRA}---------------------"
     # shellcheck disable=SC2086
     CERTINFO=$(echo | openssl s_client -servername "${DOMAIN}" -connect "${DOMAIN}:${PORT}" ${REMOTE_EXTRA} 2>/dev/null | openssl x509 2>/dev/null)
-    ISSUEDTO=$(echo "$CERTINFO" | openssl x509 -noout -subject 2>/dev/null|cut -d= -f 3-)
+    ISSUEDTO=$(echo "$CERTINFO" | openssl x509 -noout -subject 2>/dev/null| grep -Eo "/CN=[^/]+" | cut -c 5-)
     [[ -z $ISSUEDTO ]] && ISSUEDTO="-"
     debug "$ISSUEDTO"
     ISSUER=$(echo "$CERTINFO" | openssl x509 -noout -issuer 2>/dev/null| grep -Eo "/CN=[a-zA-Z' 0-9]*"| cut -c 5-)


### PR DESCRIPTION
Extract CN from cert by grep regexp. On my self certificates simple cut don't work.